### PR TITLE
feat: expected card size is 63mm x 88mm (2.5in x 3.5in)

### DIFF
--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -371,8 +371,8 @@ export default {
 }
 
 #print-content img {
-    width: 60mm;
-    height: 85mm;
+    width: 63mm;
+    height: 88mm;
     margin: 0;
     padding: 0;
 }
@@ -415,20 +415,20 @@ export default {
     }
 
     #print-content img {
-        width: 60mm;
-        height: 85mm;
+        width: 63mm;
+        height: 88mm;
         margin: 0;
         padding: 0;
     }
 
     #print-content.scale-large img {
-        width: calc(60mm * 1.02);
-        height: calc(85mm * 1.02);
+        width: calc(63mm * 1.02);
+        height: calc(88mm * 1.02);
     }
 
     #print-content.scale-small img {
-        width: calc(60mm * 0.98);
-        height: calc(85mm * 0.98);
+        width: calc(63mm * 0.98);
+        height: calc(88mm * 0.98);
     }
 
     img {


### PR DESCRIPTION
While printing my cards, I noticed that the default card size was set to 60mm x 85mm. However, the standard card size should be 63mm x 88mm (2.5in x 3.5in). I confirmed that after trying to print them out.

<details>
<summary>Comparison of printed cards with traditional cards</summary>

<img width="735" alt="Screenshot 2024-07-19 at 21 08 51" src="https://github.com/user-attachments/assets/8709afa5-8829-47ac-bbfe-c59bd9993f6e">

</details>
