### PR TITLE
fix: initial support for meld card backs (fixes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 
 ### Known Issues
 
-- Meld cards don't have backs.
 - Search is fairly specific due to exact matching.
 - Excluding basic lands and creating a list with _only_ basics is permit, but I'm pretty sure that's a stupid edge case I don't want to deal with.
 - Better mutation handling for the textarea. ie. Keep existing selections when adding additional cards.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Developer Notes
 
 - This project is intended to be deployed statically and uses a minimal list of cards bundled with the distributables.
-- Use `npm run cards` to build the card list using locally stored data, or `npm run cards-update` to force fetching an updated list from Scryfall. 
+- Use `npm run cards` to build the card list using locally stored data, or `npm run cards:update` to force fetching an updated list from Scryfall. 
 
 ### Known Issues
 
@@ -27,6 +27,7 @@
 
 ```none
 0 griselbrand
+3 Bruna, the Fading Light
 1 Bolas's Citadel
 1 Karn, the Great Creator
 1 Teferi's Protection

--- a/download-scryfall-cards.mjs
+++ b/download-scryfall-cards.mjs
@@ -93,6 +93,13 @@ const stripped = cards.filter(card => {
     return [ card ];
 }).map(card => {
     // Then set the high level data necessary to organize the remaining cards.
+    var cardBackUri = undefined;
+    if (card.card_faces?.[1]?.image_uris) {
+        cardBackUri = `https://api.scryfall.com/cards/${card.set}/${card.collector_number}?format=image&face=back`;
+    } else if (card.layout == 'meld') {
+        cardBackUri = `https://backs.scryfall.io/large/${card.card_back_id.charAt(0)}/${card.card_back_id.charAt(1)}/${card.card_back_id}.jpg`;
+    }
+
     return {
         id: card.id,
         oracleId: card.oracle_id,
@@ -108,7 +115,7 @@ const stripped = cards.filter(card => {
         isPromo: !customNotPromoSets.includes(card.set) && (card.promo || card.promo_types || customPromoSetTypes.includes(card.set_type) || customPromoSets.includes(card.set)),
         imageUris: {
             front: `https://api.scryfall.com/cards/${card.set}/${card.collector_number}?format=image&face=front`,
-            back: card.card_faces?.[1]?.image_uris ? `https://api.scryfall.com/cards/${card.set}/${card.collector_number}?format=image&face=back` : undefined,
+            back: cardBackUri,
         }
     };
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "cards": "node download-scryfall-cards.mjs",
-    "cards-update": "node download-scryfall-cards.mjs --update"
+    "cards:update": "node download-scryfall-cards.mjs --update"
   },
   "dependencies": {
     "core-js": "^3.8.3",

--- a/src/components/HelpModal.vue
+++ b/src/components/HelpModal.vue
@@ -18,7 +18,6 @@
                     <p><b>Margins:</b> I recommend <b>not</b> adjusting the margins on the page, but wish you the best of luck if you opt to.</p>
 
                     <h5>Known Issues</h5>
-                    <p><b>Meld Card Backs:</b> The back face of Meld cards are currently unprintable, but who the hell plays Meld anyways?</p>
                     <p><b>Show Promo/Digital:</b> Yeah yeah, I keep finding more stuff that doesn't fit Scryfall's data format, so there might be some promos that are lingering around that aren't properly flagged.</p>
                     <p><b>Tokens/Emblems/Etc:</b> Currently there's no focus on supporting these, so they likely won't appear. The token printing versions are a mess (especially with double faced tokens) that I haven't wanted to wade through yet.</p>
                     <p><b>Non-English:</b> There is no intended support for non-English cards, but there might be a couple that have slipped through. Scryfall's foreign card imagery is very limited for older cards, but eventually maybe I'll get the appetite to tackle it for the newer stuff.</p>

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -123,7 +123,7 @@
                         <div class="p-relative">
                             <ImageLoader class="card-image img-responsive" :src="resolveCardImage(card)" placeholder="./card_back_border_crop.jpg" :alt="card.name" />
                             <span class="card-quantity bg-primary text-light docs-shape s-rounded centered">{{ card.quantity }}x</span>
-                            <select class="form-select select-sm mt-2" v-model="card.selectedOption" @change="updateSessionSet(card.name, card.selectedOption)">
+                            <select class="form-select select-sm mt-2" name="selected-option" v-model="card.selectedOption" @change="updateSessionSet(card.name, card.selectedOption)">
                                 <option v-for="(set, index) in card.setOptions" :value="set" :key="index" v-show="shouldShowSetOption(card, set)">{{ set.name }}</option>
                             </select>
                         </div>
@@ -159,7 +159,14 @@ const basicLands = [
     'forest', 'island', 'plains', 'swamp', 'mountain',
     'snow-covered forest', 'snow-covered island',
     'snow-covered plains', 'snow-covered swamp',
-    'snow-covered mountain'];
+    'snow-covered mountain'
+];
+
+function setImageVersion(url, version) {
+    var url = new URL(url);
+    url.searchParams.set('version', version);
+    return url.href;
+}
 
 export default {
     name: 'ProxyPage',
@@ -226,17 +233,12 @@ export default {
                 return false;
             }
 
-            // Bleh, this is clunky and should be simplified.
             if (face === 'back') {
-                if (this.config.cardBacks === 'none') {
-                    return false;
-                }
-
                 if (this.config.cardBacks === 'all') {
                     return true;
                 }
 
-                if (card.selectedOption.urlBack === undefined) {
+                if (this.config.cardBacks === 'none' || card.selectedOption.urlBack === undefined) {
                     return false;
                 }
             }
@@ -245,10 +247,10 @@ export default {
         },
         resolveCardImage(card, face = 'front') {
             if (face == 'front') {
-                return `${card.selectedOption.url}&version=${this.config.imageType}`;
+                return setImageVersion(card.selectedOption.url, this.config.imageType);
             } else {
                 if (card.selectedOption.urlBack !== undefined) {
-                    return `${card.selectedOption.urlBack}&version=${this.config.imageType}`;
+                    return setImageVersion(card.selectedOption.urlBack, this.config.imageType);
                 } else {
                     return `./card_back_${this.config.imageType}.jpg`;
                 }


### PR DESCRIPTION
I only found the one card image url for the meld backs so not sure how to switch to border_crop as a version.