### PR TITLE
fix: basic fix for parenthesis card names (fixes #19)

### DIFF
--- a/src/helpers/CardNames.mjs
+++ b/src/helpers/CardNames.mjs
@@ -14,6 +14,10 @@ export function normalizeCardName(cardName) {
         // Actually, fuck it. Just use the first part of the split card name.
         .replace(/\s\/\/.+/g, '')
 
+        // Remove text in parenthesis because it gets difficult when working with the Arena deck format.
+        // This means we're not doing great matches on a couple cards, but at least they're available.
+        .replace(/\(.*\)/g, '')
+
         // Fix those dumb apostrophes and quotation marks.
         .replace(/[’‚‘‛]/g, `'`)
         .replace(/[‟”„“]/g, `"`)
@@ -22,5 +26,6 @@ export function normalizeCardName(cardName) {
         .replace(/_+/g, `_`)
 
         // Normalize case.
-        .toLowerCase();
+        .toLowerCase()
+        .trim();
 }

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -296,7 +296,9 @@ export default {
                 // Extract the quantity and card name.
                 // Cockatrice prefixes lines with "SB:" for sideboard cards, so optionally matching that.
                 // MTGA's export format puts the set and collector number in the line. ex. Arid Mesa (ZEN) 211
-                let extract = /^(?:SB:\s)?(?:(\d+)?x?\s)?([^(]+)(?:\s\(.+\) .+)?$/i.exec(line);
+                // FIXME: Need a more specific match for MTGA so I can still parse cards with parensthesis.
+                //  Ideally need to match specifically the MTGA suffix of: (SET) ###
+                let extract = /^(?:SB:\s)?(?:(\d+)?x?\s)?([^(]+).*$/i.exec(line);
                 if (extract === null) {
                     this.errors.push(line);
                     console.warn(`Failed to parse line: ${line}`);


### PR DESCRIPTION
This doesn't fix the Erase issue, need a better regex extract pattern.