### PR TITLE
misc: stop using single character json properties, split out edition definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This should generate no errors with the current match strategy.
 Deck
 0 griselbrand
 3 Bruna, the Fading Light
-1 Karn, the Great Creator
+1 Karn, the Great Creator (SLD) 501
 1 Teferi's Protection
 1 Delver of Secrets
 1 Nezumi Graverobber // Nighteyes the Desecrator

--- a/download-scryfall-cards.mjs
+++ b/download-scryfall-cards.mjs
@@ -110,7 +110,7 @@ const stripped = cards.filter(card => {
             name: card.set_name,
             code: card.set,
         },
-        setNumber: card.overridden_collector_number ?? card.collector_number,
+        collectorNumber: card.overridden_collector_number ?? card.collector_number,
         isDigital: card.digital,
         isPromo: !customNotPromoSets.includes(card.set) && (card.promo || card.promo_types || customPromoSetTypes.includes(card.set_type) || customPromoSets.includes(card.set)),
         imageUris: {
@@ -127,7 +127,7 @@ stripped.push({
         name: 'Griselbrand.com',
         code: 'Griselbrand.com',
     },
-    setNumber: '1',
+    collectorNumber: '1',
     isDigital: false,
     isPromo: false,
     imageUris: {
@@ -144,11 +144,11 @@ const minimized = stripped.sort((a, b) => {
     // So we have to strip the non-numeric characters, compare those, then fallback to the alpha comparisons.
     // Without this we get into situations where 218a < 60 can happen with alt arts and such.
     if (Date.parse(a.releaseDate) === Date.parse(b.releaseDate)) {
-        const aInt = parseInt(a.setNumber.replace(/[^0-9]/, ''));
-        const bInt = parseInt(b.setNumber.replace(/[^0-9]/, ''));
+        const aInt = parseInt(a.collectorNumber.replace(/[^0-9]/, ''));
+        const bInt = parseInt(b.collectorNumber.replace(/[^0-9]/, ''));
 
         if (aInt == bInt) {
-            return a.setNumber <= b.setNumber ? -1 : 1;
+            return a.collectorNumber <= b.collectorNumber ? -1 : 1;
         } else {
             return aInt <= bInt ? -1 : 1;
         }
@@ -161,14 +161,13 @@ const minimized = stripped.sort((a, b) => {
         const name = card.name.toLowerCase();
         store.cards[name] = store.cards[name] || [];
         store.cards[name].push({
-            s: `${card.set.code}|${card.setNumber}`,
-            d: card.isDigital ? 1 : undefined,
-            p: card.isPromo ? 1 : undefined,
+            setCode: card.set.code,
+            collectorNumber: card.collectorNumber,
+            isDigital: card.isDigital ? true : undefined,
+            isPromo: card.isPromo ? true : undefined,
 
-            // Scryfall puts a timestamp query param on these, which we don't need as it'll trigger a full regeneration each week.
-            // GZip seems to be doing a good job of optimizing out all the duplicate cdn url prefixes, so I guess it's okay to not over optimize.
-            f: card.imageUris.front,
-            b: card.imageUris.back,
+            urlFront: card.imageUris.front,
+            urlBack: card.imageUris.back,
         });
 
         store.sets[card.set.code] = card.set.name;
@@ -184,22 +183,27 @@ console.log(`Found ${Object.keys(minimized.cards).length} distinct cards from ${
 
 // Run some basic sanity tests.
 assert.equal(minimized.cards['abandon hope']?.length, 1);
-assert.equal(minimized.cards['abandon hope']?.[0].s, 'tmp|107');
-assert.match(minimized.cards['abandon hope']?.[0].f, /api\.scryfall\.com.*$/);
+assert.equal(minimized.cards['abandon hope']?.[0].setCode, 'tmp');
+assert.equal(minimized.cards['abandon hope']?.[0].collectorNumber, '107');
+assert.match(minimized.cards['abandon hope']?.[0].urlFront, /api\.scryfall\.com.*$/);
 
 assert.equal(minimized.cards['lightning dragon']?.length, 4);
-assert.equal(minimized.cards['lightning dragon']?.[0].s, 'pusg|202');
-assert.equal(minimized.cards['lightning dragon']?.[1].s, 'usg|202');
-assert.equal(minimized.cards['lightning dragon']?.[2].s, 'prm|32196');
-assert.equal(minimized.cards['lightning dragon']?.[3].s, 'vma|177');
-assert.equal(minimized.cards['lightning dragon']?.[0].d, undefined);
-assert.equal(minimized.cards['lightning dragon']?.[1].d, undefined);
-assert.equal(minimized.cards['lightning dragon']?.[2].d, 1);
-assert.equal(minimized.cards['lightning dragon']?.[3].d, 1);
-assert.equal(minimized.cards['lightning dragon']?.[0].p, 1);
-assert.equal(minimized.cards['lightning dragon']?.[1].p, undefined);
-assert.equal(minimized.cards['lightning dragon']?.[2].p, 1);
-assert.equal(minimized.cards['lightning dragon']?.[3].p, undefined);
+assert.equal(minimized.cards['lightning dragon']?.[0].setCode, 'pusg');
+assert.equal(minimized.cards['lightning dragon']?.[0].collectorNumber, '202');
+assert.equal(minimized.cards['lightning dragon']?.[1].setCode, 'usg');
+assert.equal(minimized.cards['lightning dragon']?.[1].collectorNumber, '202');
+assert.equal(minimized.cards['lightning dragon']?.[2].setCode, 'prm');
+assert.equal(minimized.cards['lightning dragon']?.[2].collectorNumber, '32196');
+assert.equal(minimized.cards['lightning dragon']?.[3].setCode, 'vma');
+assert.equal(minimized.cards['lightning dragon']?.[3].collectorNumber, '177');
+assert.equal(minimized.cards['lightning dragon']?.[0].isDigital, undefined);
+assert.equal(minimized.cards['lightning dragon']?.[1].isDigital, undefined);
+assert.equal(minimized.cards['lightning dragon']?.[2].isDigital, true);
+assert.equal(minimized.cards['lightning dragon']?.[3].isDigital, true);
+assert.equal(minimized.cards['lightning dragon']?.[0].isPromo, true);
+assert.equal(minimized.cards['lightning dragon']?.[1].isPromo, undefined);
+assert.equal(minimized.cards['lightning dragon']?.[2].isPromo, true);
+assert.equal(minimized.cards['lightning dragon']?.[3].isPromo, undefined);
 
 assert.equal(minimized.sets['tmp'], 'Tempest');
 

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -406,7 +406,7 @@ export default {
         resolveCardImage(card, face = "front") {
             if (face == "front") {
                 return setImageVersion(
-                    card.selectedOption.url,
+                    card.selectedOption.urlFront,
                     this.config.imageType,
                 );
             } else {
@@ -470,15 +470,9 @@ export default {
                     continue;
                 }
 
-                const selectedSet =
-                    line.set && line.collectorsNumber
-                        ? `${line.set}|${line.collectorsNumber}`
-                        : undefined;
-
                 const selectedOptionIndex = cardLookup.findIndex((option) => {
                     return (
-                        option.s === selectedSet ||
-                        (!selectedSet && !option.isDigital && !option.isPromo)
+                        option.setCode === line.set && option.collectorNumber == line.collectorsNumber
                     );
                 });
 
@@ -488,17 +482,15 @@ export default {
                     quantity: line.quantity,
                     name: line.name,
                     setOptions: cardLookup.map((option) => {
-                        let [setCode, setNumber] = option.s.split("|");
                         return {
-                            name: `${this.sets[setCode]} (${setNumber})`,
-                            url: option.f,
-                            urlBack: option.b,
-                            isDigital: option.d === 1,
-                            isPromo: option.p === 1,
+                            name: `${this.sets[option.setCode]} (${option.collectorNumber})`,
+                            urlFront: option.urlFront,
+                            urlBack: option.urlBack,
+                            isDigital: option.isDigital === true,
+                            isPromo: option.isPromo === true,
                         };
                     }),
                     isBasic: basicLands.includes(line.name.toLowerCase()),
-                    selectedUrl: "",
                     selectedOption: this.sessionSetSelections[line.name],
                 };
 


### PR DESCRIPTION
This increases the gzipped size by ~70kb (~3Mb unzipped), but that's not too bad for legibility.

```
  File                                 Size                                  Gzipped

  dist/js/75.5bbce23a.js               12111.97 KiB                          1169.64 KiB
  dist/js/chunk-vendors.24857d1d.js    89.25 KiB                             32.47 KiB
  dist/js/app.5b2141ef.js              22.87 KiB                             8.34 KiB
  dist/css/app.4c98bd74.css            123.87 KiB                            24.99 KiB
```