### PR TITLE
fix: use both names of flip cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ This should generate no errors with the current match strategy.
 Deck
 0 griselbrand
 3 Bruna, the Fading Light
-1 Karn, the Great Creator (SLD) 501
+1x Karn, the Great Creator (SLD) 501
 1 Teferi's Protection
-1 Delver of Secrets
-1 Nezumi Graverobber // Nighteyes the Desecrator
+1 Delver of Secrets // Insectile Aberration
+1x Nezumi Graverobber // Nighteyes the Desecrator
 1 Fire // Ice
 1 dead / GONE
 1 who /What // WHEN /wheRE // why
-1 Forest
+1x Forest (PMPS06) 5
 1 Impatient Iguana
 1 Planewide Disaster
 1 Goldmeadow

--- a/download-scryfall-cards.mjs
+++ b/download-scryfall-cards.mjs
@@ -104,7 +104,7 @@ const stripped = cards.filter(card => {
         id: card.id,
         oracleId: card.oracle_id,
         oracleName: card.name,
-        name: normalizeCardName(card.card_faces?.[0]?.image_uris ? card.card_faces[0].name : card.name),
+        name: normalizeCardName(card.name),
         releaseDate: card.released_at,
         set: {
             name: card.set_name,


### PR DESCRIPTION
Whoops, this was a bug introduced recently. Unit tests didn't catch it because they don't interact with the card list, and my test deck still had the old references.