### PR TITLE
misc: cache card list for pages action runs

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -26,9 +26,20 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - name: Cache Card List
+        uses: actions/cache@v4.0.2
+        with:
+          path: data/default-cards.json
+          key: default-cards.json-${{ hashFiles('data/default-cards.json') }}
+
       - run: echo "VUE_APP_BUILD_SHA=$GITHUB_SHA" >> $GITHUB_ENV
       - run: npm ci
-      - run: npm run cards:update
+      - run: |
+          if [[ ${{ github.event_name }} == 'schedule' ]]; then
+            npm run cards:update
+          else
+            npm run cards
+          fi
       - run: npm run build
       - run: npm run lint
       - run: npm run test


### PR DESCRIPTION
Attempting to cache the card list so that it's reused from run to run and specifically replaced during the schedule executions.