### PR TITLE
feat: switch to using an action based deploy, rather than gh-pages branch

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,8 +8,12 @@ on:
     - cron: "0 13 * * 6"
   workflow_dispatch:
 
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,9 +48,21 @@ jobs:
       - run: npm run lint
       - run: npm run test
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          cname: proxy.griselbrand.com
+          path: ./dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to Github Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Rather than building and committing to the gh-pages branch might as well just use Artifacts + Deploy Pages action.
This'll get a bunch of unnecessary commits out of here and deleting the gh-pages branch should free up a bunch of noise.