### PR TITLE
feat: rudimentary stab at saving indexed set selections

### DIFF
--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -241,6 +241,7 @@
                   updateSessionSet(
                     card.name,
                     card.selectedOption,
+                    cardIndex,
                   )
                 "
               >
@@ -437,8 +438,10 @@ export default {
                 }
             }
         },
-        updateSessionSet(cardName, setOption) {
-            this.sessionSetSelections[cardName] = setOption;
+        updateSessionSet(cardName, setOption, cardIndex) {
+            const deckIndex = this.cards.filter((v, i) => { return v.name === cardName && i <= cardIndex; }).length - 1;
+            this.sessionSetSelections[cardName] = this.sessionSetSelections[cardName] ?? {};
+            this.sessionSetSelections[cardName][deckIndex] = setOption;
         },
         printList() {
             window.print();
@@ -463,6 +466,8 @@ export default {
                     continue;
                 }
 
+                const cardIndex = _cards.filter((v) => { return v.name === line.name }).length;
+
                 const options = {
                     quantity: line.quantity,
                     name: line.name,
@@ -479,7 +484,7 @@ export default {
                         };
                     }),
                     isBasic: basicLands.includes(line.name.toLowerCase()),
-                    selectedOption: this.sessionSetSelections[line.name],
+                    selectedOption: this.sessionSetSelections[line.name]?.[cardIndex],
                 };
 
                 if (!options.selectedOption) {


### PR DESCRIPTION
I don't think I really want to get into mutating lists and tracking diffs on that, so this would be instead just tracking the number of each type of a card name in the list and storing that index for set selections. eg. `setSelections[name="fork"][index=2]`

I want to figure out a cleaner pattern for this. Need to refresh myself on how javascript can handle defaulting nested objects.