### PR TITLE
fix: corrections for CubeCobra's export format

### DIFF
--- a/download-scryfall-cards.mjs
+++ b/download-scryfall-cards.mjs
@@ -114,6 +114,17 @@ const stripped = cards.filter(card => {
             back: cardBackUri,
         },
     };
+}).flatMap(card => {
+    // Create two entries for any adventure/dfc to allow for both naming conventions.
+    // A more compact option would be to create some alias map, but this is simpler.
+    if (card.name.includes(" // ")) {
+        return [
+            card,
+            { ...card, name: card.name.split(" // ")[0] },
+        ]
+    }
+
+    return [ card ];
 });
 
 stripped.push({

--- a/src/helpers/DecklistParser.mjs
+++ b/src/helpers/DecklistParser.mjs
@@ -11,11 +11,13 @@ export function parseDecklist(decklist) {
 
         // Different sites have different sideboard formats.
         // Look for the word "sideboard" or lines that start with a double slash and skip them.
+        // CubeCobra uses # to represent a comment line.
         // MTGA uses Sideboard and Deck as section headers.
         if (
             /^Sideboard:?$/i.test(line) ||
             /^Deck:?$/i.test(line) ||
             /^\/\//.test(line) ||
+            /^#/.test(line) ||
             line === ""
         ) {
             continue;

--- a/src/helpers/DecklistParser.test.mjs
+++ b/src/helpers/DecklistParser.test.mjs
@@ -162,12 +162,17 @@ describe("parseDecklist()", () => {
                     2x Abandon Hope
                     // Another comment
                     fire // ice
+                    # comment
+                    #comment
+                    ## Comment
+                    Experiment #9
                     `,
                 ),
             ).toStrictEqual({
                 lines: [
                     { name: "abandon hope", quantity: 2 },
                     { name: "fire // ice", quantity: 1 },
+                    { name: "experiment #9", quantity: 1 },
                 ],
                 errors: [],
             });


### PR DESCRIPTION
1. Update card dataset to include references for incomplete split/flip definitions. This was something I intentionally fixed because it creates conflicts (eg. Bind vs Bind // Liberate).
2. Handle leading # as a comment line in deck parsing.