### PR TITLE
fix: update test with new card sort order

### DIFF
--- a/download-scryfall-cards.mjs
+++ b/download-scryfall-cards.mjs
@@ -202,20 +202,20 @@ assert.deepStrictEqual(
             "urlBack": "https://api.scryfall.com/cards/khm/154?format=image&face=back",
           },
           {
-            "setCode": "pkhm",
-            "collectorNumber": "154s",
-            "isDigital": undefined,
-            "isPromo": true,
-            "urlFront": "https://api.scryfall.com/cards/pkhm/154s?format=image&face=front",
-            "urlBack": "https://api.scryfall.com/cards/pkhm/154s?format=image&face=back",
-          },
-          {
             "setCode": "khm",
             "collectorNumber": "313",
             "isDigital": undefined,
             "isPromo": true,
             "urlFront": "https://api.scryfall.com/cards/khm/313?format=image&face=front",
             "urlBack": "https://api.scryfall.com/cards/khm/313?format=image&face=back",
+          },
+          {
+            "setCode": "pkhm",
+            "collectorNumber": "154s",
+            "isDigital": undefined,
+            "isPromo": true,
+            "urlFront": "https://api.scryfall.com/cards/pkhm/154s?format=image&face=front",
+            "urlBack": "https://api.scryfall.com/cards/pkhm/154s?format=image&face=back",
           },
           {
             "setCode": "prm",


### PR DESCRIPTION
Unclear why this order was evaluated, I can't see any changes to the release date on these cards and I don't see a reason why it would be be evaluating the collector numbers in the wrong order... Need to look into that.