### PR TITLE
misc: update gh-pages build to node v24.x

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5.0.0
         with:
-          node-version: "22.x"
+          node-version: "24.x"
 
       - name: Cache dependencies
         uses: actions/cache@v4.2.4


### PR DESCRIPTION
The PR build was already doing 24, so this is just to align them. That was a miss.