### PR TITLE
fix: modify how fronts then backs is applied (fixes #518)

### DIFF
--- a/src/views/ProxyPage.test.mjs
+++ b/src/views/ProxyPage.test.mjs
@@ -129,10 +129,11 @@ describe('Print layout', async () => {
         const backSlots = pages[1].slots.slice(0, 3).map((slot) => slot.card.name);
 
         expect(frontSlots).toEqual(['alpha', 'bravo', 'charlie']);
-        expect(backSlots).toEqual(['charlie', 'bravo', 'alpha']);
+        // Back slots are in the same order; row-mirroring is handled via CSS direction: rtl
+        expect(backSlots).toEqual(['alpha', 'bravo', 'charlie']);
     });
 
-    test('All pages mode doubles page count and pads', () => {
+    test('All pages mode produces front and back page groups', () => {
         const data = wrapper.getCurrentComponent().data;
         const ctx = wrapper.getCurrentComponent().ctx;
 
@@ -147,12 +148,10 @@ describe('Print layout', async () => {
         });
 
         const pages = ctx.printPages;
-        expect(pages.length).toBe(4);
-        expect(pages[0].slots.length).toBe(9);
-        expect(pages[1].slots.length).toBe(9);
-        expect(pages[2].slots.length).toBe(9);
-        expect(pages[3].slots.length).toBe(9);
-        expect(pages[1].slots.filter(Boolean).length).toBe(1);
-        expect(pages[3].slots.filter(Boolean).length).toBe(1);
+        expect(pages.length).toBe(2);
+        expect(pages[0].slots.length).toBe(10);
+        expect(pages[1].slots.length).toBe(10);
+        expect(pages[0].isBack).toBe(false);
+        expect(pages[1].isBack).toBe(true);
     });
 });

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -273,7 +273,7 @@
   >
     <template v-for="(page, pageIndex) in printPages" :key="`page-${pageIndex}`">
       <div class="print-page">
-        <div class="print-grid">
+        <div class="print-grid" :class="{ 'print-grid-backs': page.isBack }">
           <template v-for="(slot, slotIndex) in page.slots" :key="`page-${pageIndex}-${slotIndex}`">
             <img
               v-if="slot"
@@ -320,31 +320,6 @@ function setImageVersion(url, version) {
     } else {
         return url;
     }
-}
-
-function chunkAndPad(items, size) {
-    if (items.length === 0) {
-        return [];
-    }
-
-    const pages = [];
-    for (let i = 0; i < items.length; i += size) {
-        const page = items.slice(i, i + size);
-        while (page.length < size) {
-            page.push(null);
-        }
-        pages.push(page);
-    }
-
-    return pages;
-}
-
-function mirrorPageByRow(page, columns) {
-    const mirrored = [];
-    for (let i = 0; i < page.length; i += columns) {
-        mirrored.push(...page.slice(i, i + columns).reverse());
-    }
-    return mirrored;
 }
 
 export default {
@@ -405,17 +380,12 @@ export default {
             return slots;
         },
         printPages() {
-            const pageSize = 9;
-            const columns = 3;
-
             if (this.config.cardBacks === "none") {
                 const slots = this.printSlotsFront.map((card) => {
                     return { card, face: "front" };
                 });
 
-                return chunkAndPad(slots, pageSize).map((page) => {
-                    return { slots: page, isBack: false };
-                });
+                return [{ slots, isBack: false }];
             }
 
             if (this.config.cardBacks === "all-pages") {
@@ -426,14 +396,10 @@ export default {
                     return { card, face: "back" };
                 });
 
-                const frontPages = chunkAndPad(frontSlots, pageSize).map((page) => {
-                    return { slots: page, isBack: false };
-                });
-                const backPages = chunkAndPad(backSlots, pageSize).map((page) => {
-                    return { slots: mirrorPageByRow(page, columns), isBack: true };
-                });
-
-                return [...frontPages, ...backPages];
+                return [
+                    { slots: frontSlots, isBack: false },
+                    { slots: backSlots, isBack: true },
+                ];
             }
 
             const slots = [];
@@ -451,9 +417,7 @@ export default {
                 }
             }
 
-            return chunkAndPad(slots, pageSize).map((page) => {
-                return { slots: page, isBack: false };
-            });
+            return [{ slots, isBack: false }];
         },
     },
     mounted() {
@@ -681,10 +645,13 @@ html.dark-theme {
 }
 
 #print-content .print-grid {
-    display: grid;
-    grid-template-columns: repeat(3, var(--card-width));
-    grid-auto-rows: var(--card-height);
+    display: flex;
+    flex-wrap: wrap;
     gap: 0;
+}
+
+#print-content .print-grid-backs {
+    direction: rtl;
 }
 
 @media print {
@@ -749,11 +716,10 @@ html.dark-theme {
         width: 100%;
         display: flex;
         justify-content: center;
-        break-after: page;
     }
 
-    .print-page:last-child {
-        break-after: auto;
+    .print-page + .print-page {
+        break-before: page;
     }
 }
 </style>


### PR DESCRIPTION
The fronts then backs print mode was enforcing a 3 column layout because it needed to control how the images aligned across different pages. This was causing issues with any print arrangement that didn't want exactly 3 columns (like Landscape). 

The change is to use an alternate method of applying that that does the alignment using css to mirror the page content.