### PR TITLE
Improve token and game piece imports

### DIFF
--- a/download-scryfall-cards.mjs
+++ b/download-scryfall-cards.mjs
@@ -37,6 +37,8 @@ for await (const { value } of pipeline) {
     cards.push(value);
 }
 
+const cardsById = new Map(cards.map(card => [card.id, card]));
+
 const customPromoSetTypes = [
     'from_the_vault',
     'spellbook',
@@ -86,6 +88,14 @@ const excludedLayouts = [
     'art_series',
 ];
 
+function isGamePiece(card) {
+    return card.layout === 'token' ||
+        card.layout === 'double_faced_token' ||
+        card.layout === 'emblem' ||
+        card.type_line === 'Card' ||
+        /(^| — | \/\/ )(Dungeon|Emblem|Plane|Scheme)( — | \/\/ |$)/.test(card.type_line);
+}
+
 const stripped = cards.filter(card => {
     // Process the exclusions.
     return includedSets.includes(card.set) ||
@@ -113,12 +123,24 @@ const stripped = cards.filter(card => {
     }
 
     const applicablePromoTypes = (card.promo_types || []).filter(pt => !notPromoTypes.includes(pt));
+    const relatedTokens = card.all_parts
+        ?.filter(part => part.component === 'token')
+        .map(part => cardsById.get(part.id))
+        .filter(token => token && (token.layout === 'token' || token.layout === 'double_faced_token'))
+        .map(token => {
+            return {
+                name: normalizeCardName(token.name),
+                setCode: token.set,
+                collectorNumber: token.collector_number,
+            };
+        });
 
     return {
         id: card.id,
         oracleId: card.oracle_id,
         oracleName: card.name,
         name: normalizeCardName(card.name),
+        flavorName: card.flavor_name ? normalizeCardName(card.flavor_name) : undefined,
         releaseDate: card.released_at,
         set: {
             name: card.set_name,
@@ -128,6 +150,8 @@ const stripped = cards.filter(card => {
         isDigital: card.digital,
         isPromo: !customNotPromoSets.includes(card.set) && (card.promo || applicablePromoTypes.length > 0 || customPromoSetTypes.includes(card.set_type) || customPromoSets.includes(card.set)),
         isToken: card.layout === 'token' || card.layout === 'double_faced_token',
+        isGamePiece: isGamePiece(card),
+        relatedTokens: relatedTokens?.length ? relatedTokens : undefined,
         imageUris: {
             front: `https://cards.scryfall.io/border_crop/${card.reversible_face || 'front'}/${card.id.charAt(0)}/${card.id.charAt(1)}/${card.id}.jpg`,
             back: cardBackUri,
@@ -136,14 +160,17 @@ const stripped = cards.filter(card => {
 }).flatMap(card => {
     // Create two entries for any adventure/dfc to allow for both naming conventions.
     // A more compact option would be to create some alias map, but this is simpler.
+    const aliases = [ card ];
+
     if (card.name.includes(" // ")) {
-        return [
-            card,
-            { ...card, name: card.name.split(" // ")[0] },
-        ]
+        aliases.push({ ...card, name: card.name.split(" // ")[0] });
     }
 
-    return [ card ];
+    if (card.flavorName) {
+        aliases.push({ ...card, name: card.flavorName });
+    }
+
+    return aliases;
 });
 
 stripped.push({
@@ -193,6 +220,8 @@ const minimized = stripped.sort((a, b) => {
             isDigital: card.isDigital ? true : undefined,
             isPromo: card.isPromo ? true : undefined,
             isToken: card.isToken ? true : undefined,
+            ...(card.isGamePiece ? { isGamePiece: true } : {}),
+            ...(card.relatedTokens ? { relatedTokens: card.relatedTokens } : {}),
 
             urlFront: card.imageUris.front,
             urlBack: card.imageUris.back,

--- a/feature_files/decklist-token-set-identification.feature.md
+++ b/feature_files/decklist-token-set-identification.feature.md
@@ -1,0 +1,43 @@
+# Decklist Token Set Identification
+
+## Purpose
+
+- Token imports from wishlist-style decklists should resolve to the intended token family.
+- Bracketed short codes such as `[tsos]` should be useful even when no collector number is present.
+
+## User-visible behavior
+
+- A token line with a bracketed set code selects a token printing from that set.
+- A token line with both set code and collector number selects that exact token printing.
+- Token lines with missing edition text can be completed from tokens associated with cards in the same imported session.
+- Associated token completion preserves complete token edition text and manual session selections.
+- Game pieces include tokens, reminders, trackers, mechanic helpers, dungeons, initiative, ring cards, and emblems for print back behavior.
+- Game pieces are paired on opposite sides with different game pieces when possible; identical game pieces leave the opposite side empty instead of duplicating.
+- The print controls show open physical card slots and open game piece faces for the current page size.
+- Moxfield tags such as `#!ramp` are ignored after card edition text.
+- Flavor names such as `Aang's Shelter` resolve to the original Scryfall card printing.
+- If no matching token printing is found, import falls back to the existing default selection behavior.
+
+## Key flows
+
+- Importing `Pest [tsos]` selects a `Pest` token from `TSOS`.
+- Importing `Pest [tsos] 9` selects `Pest` from `TSOS` collector number `9`.
+- Importing `Pestbrood Sloth` and `Pest` selects the `Pest` token associated with `Pestbrood Sloth`.
+- Importing `Pestbrood Sloth` and `Pest [tsos] 8` keeps `Pest` on collector number `8`.
+- Printing `Experience` in token-opposite back mode uses its front image on the opposite side.
+- Printing four `Treasure`, one `Pest`, and one `Experience` uses four physical cards, with two empty opposite-side faces.
+- Importing `Aang's Shelter` selects `Teferi's Protection` from `TLE` collector number `7`.
+- Importing a token without set information keeps using the existing default.
+
+## Constraints
+
+- Set codes are parsed from short bracketed values.
+- Collector numbers remain the exact-print discriminator when present.
+- Set-only token imports may still have multiple art variants within a set; the first matching dataset option is selected.
+
+## Test anchors
+
+- Feature: Bracketed set code selects token printing.
+- Feature: Bracketed set code and collector number select exact token printing.
+- Feature: Associated session cards complete missing token edition text.
+- Feature: Flavor name imports resolve to original card printings.

--- a/src/helpers/DecklistParser.mjs
+++ b/src/helpers/DecklistParser.mjs
@@ -27,7 +27,7 @@ export function parseDecklist(decklist) {
         // Cockatrice prefixes lines with "SB:" for sideboard cards, so optionally matching that.
         // Last I knew MTGA's export format puts the set and collector number in the line. ex. Arid Mesa (ZEN) 211
         const extract =
-            /^(?:SB:\s+)?(?:(\d+)?x?\s)?(.+?)\s*(?:\(([^()]*)\)\s+([-\w★]+))?$/i.exec(
+            /^(?:SB:\s+)?(?:(\d+)\s*x?\s)?(.+?)\s*(?:\(([^()]*)\)(?:\s+([-\w★]+))?|\[([^\]]+)\])?$/i.exec(
                 line,
             );
 
@@ -41,9 +41,12 @@ export function parseDecklist(decklist) {
             ,
             quantity,
             inputCardName,
-            setName = undefined,
+            parenSet = undefined,
             collectorsNumber = undefined,
+            bracketSet = undefined,
         ] = extract;
+
+        const setName = (parenSet || bracketSet) ? (parenSet || bracketSet) : undefined;
 
         if (quantity === undefined) {
             quantity = 1;

--- a/src/helpers/DecklistParser.mjs
+++ b/src/helpers/DecklistParser.mjs
@@ -23,6 +23,8 @@ export function parseDecklist(decklist) {
             continue;
         }
 
+        line = line.replace(/\s+#!\S+/g, "").trim();
+
         // Extract the quantity and card name.
         // Cockatrice prefixes lines with "SB:" for sideboard cards, so optionally matching that.
         // Last I knew MTGA's export format puts the set and collector number in the line. ex. Arid Mesa (ZEN) 211

--- a/src/helpers/DecklistParser.mjs
+++ b/src/helpers/DecklistParser.mjs
@@ -27,7 +27,7 @@ export function parseDecklist(decklist) {
         // Cockatrice prefixes lines with "SB:" for sideboard cards, so optionally matching that.
         // Last I knew MTGA's export format puts the set and collector number in the line. ex. Arid Mesa (ZEN) 211
         const extract =
-            /^(?:SB:\s+)?(?:(\d+)\s*x?\s)?(.+?)\s*(?:\(([^()]*)\)(?:\s+([-\w★]+))?|\[([^\]]+)\])?$/i.exec(
+            /^(?:SB:\s+)?(?:(\d+)\s*x?\s)?(.+?)\s*(?:\(([^()]*)\)\s+([-\w★]+)|\[([^\]]+)\](?:\s+([-\w★]+))?)?$/i.exec(
                 line,
             );
 
@@ -42,11 +42,13 @@ export function parseDecklist(decklist) {
             quantity,
             inputCardName,
             parenSet = undefined,
-            collectorsNumber = undefined,
+            collectorsNumberFromParen = undefined,
             bracketSet = undefined,
+            collectorsNumberFromBracket = undefined,
         ] = extract;
 
-        const setName = (parenSet || bracketSet) ? (parenSet || bracketSet) : undefined;
+        const setName = parenSet || bracketSet;
+        const collectorsNumber = collectorsNumberFromParen || collectorsNumberFromBracket;
 
         if (quantity === undefined) {
             quantity = 1;

--- a/src/helpers/DecklistParser.test.mjs
+++ b/src/helpers/DecklistParser.test.mjs
@@ -92,6 +92,33 @@ describe("parseDecklist()", () => {
                 errors: [],
             });
         });
+
+        test("Moxfield tags are ignored after card edition text", () => {
+            expect(
+                parseDecklist(
+                    `
+                        arcane signet (tdc) 105 #!mana_dork #!mana_p
+                        blood artist (soc) 209 #!d_c #!life_p #!ping_p
+                        farseek (fic) 302 #!ramp
+                        mayhem devil (plst) war-204 #!ping_p #!sacrifice_c
+                        open the omenpaths (khm) 143 #!mana_p
+                        smothering abomination (soc) 226 #!card_advantage #!sacrifice_c #!sacrifice_p
+                        vengeful bloodwitch (fdn) 76 #!d_c #!life_p #!ping_p
+                    `,
+                ),
+            ).toStrictEqual({
+                errors: [],
+                lines: [
+                    { name: "arcane signet", quantity: 1, set: "tdc", collectorsNumber: "105" },
+                    { name: "blood artist", quantity: 1, set: "soc", collectorsNumber: "209" },
+                    { name: "farseek", quantity: 1, set: "fic", collectorsNumber: "302" },
+                    { name: "mayhem devil", quantity: 1, set: "plst", collectorsNumber: "war-204" },
+                    { name: "open the omenpaths", quantity: 1, set: "khm", collectorsNumber: "143" },
+                    { name: "smothering abomination", quantity: 1, set: "soc", collectorsNumber: "226" },
+                    { name: "vengeful bloodwitch", quantity: 1, set: "fdn", collectorsNumber: "76" },
+                ],
+            });
+        });
     });
 
     describe("Ignored Lines", () => {
@@ -353,6 +380,25 @@ describe("parseDecklist()", () => {
                     { name: "graveborn", quantity: 1, set: "tcmm" },
                     { name: "graveborn", quantity: 23 },
                     { name: "graveborn", quantity: 1 },
+                ],
+                errors: [],
+            });
+        });
+
+        test("Bracket codes are treated as set codes", () => {
+            const input = `
+                1 Card Name [zen]
+                1 Card Name [mma]
+                1 Pest [tsos]
+                1 Pest [tsos] 9
+            `;
+
+            expect(parseDecklist(input)).toStrictEqual({
+                lines: [
+                    { name: "card name", quantity: 1, set: "zen" },
+                    { name: "card name", quantity: 1, set: "mma" },
+                    { name: "pest", quantity: 1, set: "tsos" },
+                    { name: "pest", quantity: 1, set: "tsos", collectorsNumber: "9" },
                 ],
                 errors: [],
             });

--- a/src/helpers/DecklistParser.test.mjs
+++ b/src/helpers/DecklistParser.test.mjs
@@ -333,4 +333,29 @@ describe("parseDecklist()", () => {
             });
         });
     });
+
+    describe("Bracketed set codes and quantity variants", () => {
+        test("Various bracket and quantity forms", () => {
+            const input = `
+                1x Graveborn [tcmm]
+                1x Graveborn
+                1 Graveborn [tcmm]
+                Graveborn [tcmm]
+                23 Graveborn
+                Graveborn
+            `;
+
+            expect(parseDecklist(input)).toStrictEqual({
+                lines: [
+                    { name: "graveborn", quantity: 1, set: "tcmm" },
+                    { name: "graveborn", quantity: 1 },
+                    { name: "graveborn", quantity: 1, set: "tcmm" },
+                    { name: "graveborn", quantity: 1, set: "tcmm" },
+                    { name: "graveborn", quantity: 23 },
+                    { name: "graveborn", quantity: 1 },
+                ],
+                errors: [],
+            });
+        });
+    });
 });

--- a/src/views/ProxyPage.test.mjs
+++ b/src/views/ProxyPage.test.mjs
@@ -36,6 +36,135 @@ describe('Deck Loading', async () => {
     test('Has Card Entry', () => {
         expect(wrapper.findAll('.card-select').length).toBe(1);
     })
+
+    test('Feature: Bracketed set code selects token printing.', async () => {
+        const component = wrapper.getCurrentComponent();
+
+        component.data.config.matchEditions = false;
+        component.data.config.decklist = 'Pest [tsos]';
+        await component.ctx.loadCardList();
+
+        const cards = component.data.cards;
+
+        expect(cards.length).toBe(1);
+        expect(cards[0].name).toBe('pest');
+        expect(cards[0].selectedOption.isToken).toBe(true);
+        expect(cards[0].selectedOption.isGamePiece).toBe(true);
+        expect(cards[0].selectedOption.setCode).toBe('tsos');
+    });
+
+    test('Feature: Bracketed set code and collector number select exact token printing.', async () => {
+        const component = wrapper.getCurrentComponent();
+
+        component.data.config.matchEditions = false;
+        component.data.config.decklist = 'Pest [tsos] 9';
+        await component.ctx.loadCardList();
+
+        const cards = component.data.cards;
+
+        expect(cards.length).toBe(1);
+        expect(cards[0].name).toBe('pest');
+        expect(cards[0].selectedOption.isToken).toBe(true);
+        expect(cards[0].selectedOption.isGamePiece).toBe(true);
+        expect(cards[0].selectedOption.setCode).toBe('tsos');
+        expect(cards[0].selectedOption.collectorNumber).toBe('9');
+    });
+
+    test('Feature: Associated session cards complete missing token edition text.', async () => {
+        const component = wrapper.getCurrentComponent();
+
+        component.data.config.matchEditions = false;
+        component.data.config.decklist = `
+            Pestbrood Sloth
+            Pest
+        `;
+        await component.ctx.loadCardList();
+
+        const cards = component.data.cards;
+        const pest = cards.find(card => card.name === 'pest');
+
+        expect(pest.selectedOption.isToken).toBe(true);
+        expect(pest.selectedOption.setCode).toBe('tsos');
+        expect(pest.selectedOption.collectorNumber).toBe('9');
+    });
+
+    test('Feature: Associated session cards complete missing token collector number only.', async () => {
+        const component = wrapper.getCurrentComponent();
+
+        component.data.config.matchEditions = false;
+        component.data.config.decklist = `
+            Pestbrood Sloth
+            Pest [tsos]
+        `;
+        await component.ctx.loadCardList();
+
+        const cards = component.data.cards;
+        const pest = cards.find(card => card.name === 'pest');
+
+        expect(pest.selectedOption.isToken).toBe(true);
+        expect(pest.selectedOption.setCode).toBe('tsos');
+        expect(pest.selectedOption.collectorNumber).toBe('9');
+    });
+
+    test('Feature: Associated session cards preserve complete token edition text.', async () => {
+        const component = wrapper.getCurrentComponent();
+
+        component.data.config.matchEditions = false;
+        component.data.config.decklist = `
+            Pestbrood Sloth
+            Pest [tsos] 8
+        `;
+        await component.ctx.loadCardList();
+
+        const cards = component.data.cards;
+        const pest = cards.find(card => card.name === 'pest');
+
+        expect(pest.selectedOption.isToken).toBe(true);
+        expect(pest.selectedOption.setCode).toBe('tsos');
+        expect(pest.selectedOption.collectorNumber).toBe('8');
+    });
+
+    test('Feature: Session token selections are preserved over associated token completion.', async () => {
+        const component = wrapper.getCurrentComponent();
+
+        component.data.config.matchEditions = false;
+        component.data.sessionSetSelections.pest = [
+            {
+                name: 'Secrets of Strixhaven Tokens (8)',
+                setCode: 'tsos',
+                collectorNumber: '8',
+                isToken: true,
+                urlFront: 'selected-token',
+            },
+        ];
+        component.data.config.decklist = `
+            Pestbrood Sloth
+            Pest
+        `;
+        await component.ctx.loadCardList();
+
+        const cards = component.data.cards;
+        const pest = cards.find(card => card.name === 'pest');
+
+        expect(pest.selectedOption.collectorNumber).toBe('8');
+
+        component.data.sessionSetSelections.pest = undefined;
+    });
+
+    test('Feature: Flavor name imports resolve to original card printings.', async () => {
+        const component = wrapper.getCurrentComponent();
+
+        component.data.config.matchEditions = false;
+        component.data.config.decklist = "Aang's Shelter";
+        await component.ctx.loadCardList();
+
+        const cards = component.data.cards;
+
+        expect(cards.length).toBe(1);
+        expect(cards[0].name).toBe("aang's shelter");
+        expect(cards[0].selectedOption.setCode).toBe('tle');
+        expect(cards[0].selectedOption.collectorNumber).toBe('7');
+    });
 });
 
 describe('shouldShowSetOption()', async () => {
@@ -178,20 +307,100 @@ describe('Print layout', async () => {
         expect(pages[3].isBack).toBe(true);
     });
 
-    test('All pages token opposite mode uses token front for back images', () => {
+    test('All pages opposite mode leaves duplicate game piece backs empty', () => {
         const data = wrapper.getCurrentComponent().data;
         const ctx = wrapper.getCurrentComponent().ctx;
 
         data.config.cardBacks = 'all-pages';
         data.config.tokenBackMode = 'opposite';
         data.config.imageType = 'normal';
-        const tokenCard = { quantity: 1, name: 'tiny', isBasic: false, selectedOption: { urlFront: 'token-front', urlBack: 'token-back', isToken: true } };
+        data.config.fixedPageSize = false;
+        data.config.cardsPerPage = null;
+        const tokenCard = { quantity: 1, name: 'tiny', isBasic: false, selectedOption: { urlFront: 'token-front', urlBack: 'token-back', isToken: true, isGamePiece: true } };
         data.cards = [tokenCard];
 
         const pages = ctx.printPages;
         expect(pages.length).toBe(2);
-        // ensure back page uses token front as image when resolved
-        const backSlot = pages[1].slots[0];
-        expect(ctx.resolveCardImage(backSlot.card, 'back')).toContain('token-front');
+        expect(pages[0].slots[0].card.name).toBe('tiny');
+        expect(pages[1].slots[0]).toBe(null);
+    });
+
+    test('All pages opposite mode pairs different game pieces', () => {
+        const data = wrapper.getCurrentComponent().data;
+        const ctx = wrapper.getCurrentComponent().ctx;
+
+        data.config.cardBacks = 'all-pages';
+        data.config.tokenBackMode = 'opposite';
+        data.config.fixedPageSize = true;
+        data.config.cardsPerPage = null;
+        data.cards = [
+            {
+                quantity: 4,
+                name: 'treasure',
+                isBasic: false,
+                selectedOption: { setCode: 'tfin', collectorNumber: '1', urlFront: 'treasure-front', isToken: true, isGamePiece: true },
+            },
+            {
+                quantity: 1,
+                name: 'pest',
+                isBasic: false,
+                selectedOption: { setCode: 'tsos', collectorNumber: '9', urlFront: 'pest-front', isToken: true, isGamePiece: true },
+            },
+            {
+                quantity: 1,
+                name: 'experience',
+                isBasic: false,
+                selectedOption: { setCode: 'tc15', collectorNumber: '0', urlFront: 'experience-front', isGamePiece: true },
+            },
+        ];
+
+        const pages = ctx.printPages;
+        const frontNames = pages[0].slots.filter(Boolean).map(slot => slot.card.name);
+        const backNames = pages[1].slots.filter(Boolean).map(slot => slot.card.name);
+
+        expect(frontNames).toEqual(['treasure', 'treasure', 'treasure', 'treasure']);
+        expect(backNames).toEqual(['pest', 'experience']);
+        expect(pages[1].slots.slice(2).every(slot => slot === null)).toBe(true);
+        expect(ctx.printCapacity.missingCards).toBe(5);
+        expect(ctx.printCapacity.missingGamePieces).toBe(12);
+    });
+
+    test('All pages game piece opposite mode uses paired front images on backs', async () => {
+        const data = wrapper.getCurrentComponent().data;
+        const ctx = wrapper.getCurrentComponent().ctx;
+
+        data.config.cardBacks = 'all-pages';
+        data.config.tokenBackMode = 'opposite';
+        data.config.imageType = 'normal';
+        data.config.fixedPageSize = false;
+        data.config.cardsPerPage = null;
+        data.config.decklist = 'Experience';
+        await ctx.loadCardList();
+
+        const experience = data.cards[0];
+
+        expect(experience.selectedOption.isToken).toBe(undefined);
+        expect(experience.selectedOption.isGamePiece).toBe(true);
+        expect(ctx.resolveCardImage({ selectedOption: experience.selectedOption }, 'front')).toContain('73805b39-7624-4fbd-bcc0-4241e733a97f');
+    });
+
+    test('Single-sided printing reports one game piece face per empty physical card', () => {
+        const data = wrapper.getCurrentComponent().data;
+        const ctx = wrapper.getCurrentComponent().ctx;
+
+        data.config.cardBacks = 'none';
+        data.config.fixedPageSize = true;
+        data.config.cardsPerPage = null;
+        data.cards = [
+            {
+                quantity: 6,
+                name: 'treasure',
+                isBasic: false,
+                selectedOption: { urlFront: 'treasure-front', isToken: true, isGamePiece: true },
+            },
+        ];
+
+        expect(ctx.printCapacity.missingCards).toBe(3);
+        expect(ctx.printCapacity.missingGamePieces).toBe(3);
     });
 });

--- a/src/views/ProxyPage.test.mjs
+++ b/src/views/ProxyPage.test.mjs
@@ -13,7 +13,7 @@ beforeAll(async () => {
     while(Object.keys(wrapper.getCurrentComponent().data.sets).length === 0) {
         await new Promise(r => setTimeout(r, 50));
     }
-}, 10000);
+}, 30000);
 
 describe('Core Rendering', async () => {
     test('Renders', () => {
@@ -153,5 +153,22 @@ describe('Print layout', async () => {
         expect(pages[1].slots.length).toBe(10);
         expect(pages[0].isBack).toBe(false);
         expect(pages[1].isBack).toBe(true);
+    });
+
+    test('All pages token opposite mode uses token front for back images', () => {
+        const data = wrapper.getCurrentComponent().data;
+        const ctx = wrapper.getCurrentComponent().ctx;
+
+        data.config.cardBacks = 'all-pages';
+        data.config.tokenBackMode = 'opposite';
+        data.config.imageType = 'normal';
+        const tokenCard = { quantity: 1, name: 'tiny', isBasic: false, selectedOption: { urlFront: 'token-front', urlBack: 'token-back', isToken: true } };
+        data.cards = [tokenCard];
+
+        const pages = ctx.printPages;
+        expect(pages.length).toBe(2);
+        // ensure back page uses token front as image when resolved
+        const backSlot = pages[1].slots[0];
+        expect(ctx.resolveCardImage(backSlot.card, 'back')).toContain('token-front');
     });
 });

--- a/src/views/ProxyPage.test.mjs
+++ b/src/views/ProxyPage.test.mjs
@@ -13,7 +13,7 @@ beforeAll(async () => {
     while(Object.keys(wrapper.getCurrentComponent().data.sets).length === 0) {
         await new Promise(r => setTimeout(r, 50));
     }
-}, 10000);
+}, 30000);
 
 describe('Core Rendering', async () => {
     test('Renders', () => {

--- a/src/views/ProxyPage.test.mjs
+++ b/src/views/ProxyPage.test.mjs
@@ -154,4 +154,27 @@ describe('Print layout', async () => {
         expect(pages[0].isBack).toBe(false);
         expect(pages[1].isBack).toBe(true);
     });
+
+    test('All pages mode alternates front and back pages when fixed page size is used', () => {
+        const data = wrapper.getCurrentComponent().data;
+        const ctx = wrapper.getCurrentComponent().ctx;
+
+        data.config.cardBacks = 'all-pages';
+        data.config.fixedPageSize = true;
+        data.cards = Array.from({ length: 10 }, (_, i) => {
+            return {
+                quantity: 1,
+                name: `card-${i + 1}`,
+                isBasic: false,
+                selectedOption: { urlFront: `front-${i + 1}`, urlBack: `back-${i + 1}` },
+            };
+        });
+
+        const pages = ctx.printPages;
+        expect(pages.length).toBe(4);
+        expect(pages[0].isBack).toBe(false);
+        expect(pages[1].isBack).toBe(true);
+        expect(pages[2].isBack).toBe(false);
+        expect(pages[3].isBack).toBe(true);
+    });
 });

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -117,13 +117,7 @@
                 <i class="form-icon" /> Fixed page size (3×3)
               </label>
             </div>
-            <div class="column col-12">
-              <label class="form-label">
-                <i class="form-icon" /> Cards per page
-                <input type="number" min="1" max="36" class="form-input" v-model.number="config.cardsPerPage" placeholder="9" style="width:100%" />
-                <small class="form-help">Used when <strong>Card backs</strong> = All pages and Fixed page size is unchecked.</small>
-              </label>
-            </div>
+            
           </div>
           <div class="column col-12 divider" />
           <div class="columns">

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -37,13 +37,21 @@
 
           <div class="form-group btn-group btn-group-block">
             <div id="slot-usage" class="bar">
-              <template v-for="index in 9" :key="index">
+              <template v-for="index in printCapacity.pageSize" :key="index">
                 <div
                   :class="`bar-item ${index <= cardCountWhenPrinting.overflow ? 'consumed' : 'unconsumed'}`"
                   role="progressbar"
                 />
               </template>
             </div>
+          </div>
+          <div
+            v-if="cards.length"
+            id="print-capacity"
+            class="text-small text-gray"
+          >
+            Open: {{ printCapacity.missingCards }} card slot{{ printCapacity.missingCards === 1 ? '' : 's' }}
+            / {{ printCapacity.missingGamePieces }} game piece face{{ printCapacity.missingGamePieces === 1 ? '' : 's' }}
           </div>
 
           <div class="spacer" style="height: 0.4rem" />
@@ -384,18 +392,43 @@ export default {
     },
     computed: {
         cardCountWhenPrinting() {
-            const count = this.printPages.reduce((total, page) => {
-                return total + page.slots.filter(Boolean).length;
-            }, 0);
+            const count = this.printCapacity.physicalCards;
 
-            const overflow = count % 9;
-            const bound = overflow == 0 ? count : count + (9 - (count % 9));
+            const overflow = count % this.printCapacity.pageSize;
+            const bound = overflow == 0 ? count : count + (this.printCapacity.pageSize - overflow);
 
             return {
                 count,
                 overflow,
                 bound,
-                percentage: Math.round((overflow / 9) * 100),
+                percentage: Math.round((overflow / this.printCapacity.pageSize) * 100),
+            };
+        },
+        printCapacity() {
+            const pageSize = this.getPrintPageSize();
+            const frontPages = this.printPages.filter(page => !page.isBack);
+            const usesGamePieceBacks = this.config.cardBacks === "all-pages" &&
+                this.config.tokenBackMode === "opposite";
+            const physicalCards = usesGamePieceBacks
+                ? frontPages.reduce((total, page) => {
+                    return total + page.slots.filter(Boolean).length;
+                }, 0)
+                : this.printSlotsFront.length;
+            const pageCount = Math.max(Math.ceil(physicalCards / pageSize), physicalCards > 0 ? 1 : 0);
+            const physicalCapacity = pageCount * pageSize;
+            const missingCards = Math.max(0, physicalCapacity - physicalCards);
+            const printedFaces = this.printPages.reduce((total, page) => {
+                return total + page.slots.filter(Boolean).length;
+            }, 0);
+            const missingGamePieces = usesGamePieceBacks
+                ? Math.max(0, physicalCapacity * 2 - printedFaces)
+                : missingCards;
+
+            return {
+                pageSize,
+                physicalCards,
+                missingCards,
+                missingGamePieces,
             };
         },
         printSlotsFront() {
@@ -453,12 +486,17 @@ export default {
             }
 
             if (this.config.cardBacks === "all-pages") {
-              const frontSlots = this.printSlotsFront.map((card) => {
-                return { card, face: "front" };
-              });
-              const backSlots = this.printSlotsFront.map((card) => {
-                return { card, face: "back" };
-              });
+              const pairedSlots = this.config.tokenBackMode === "opposite"
+                ? this.buildPairedGamePieceSlots(this.printSlotsFront)
+                : {
+                    frontSlots: this.printSlotsFront.map((card) => {
+                      return { card, face: "front" };
+                    }),
+                    backSlots: this.printSlotsFront.map((card) => {
+                      return { card, face: "back" };
+                    }),
+                  };
+              const { frontSlots, backSlots } = pairedSlots;
 
               const pageSize = this.config.fixedPageSize ? 9 : (this.config.cardsPerPage ?? null);
               const frontPages = toPages(frontSlots, false, pageSize);
@@ -501,6 +539,85 @@ export default {
         this.initConfig();
     },
     methods: {
+        getPrintPageSize() {
+            if (this.config.fixedPageSize) {
+                return 9;
+            }
+
+            return Number.isInteger(this.config.cardsPerPage) && this.config.cardsPerPage > 0
+                ? this.config.cardsPerPage
+                : 9;
+        },
+        isGamePieceCard(card) {
+            return Boolean(card.selectedOption?.isGamePiece);
+        },
+        gamePieceKey(card) {
+            return [
+                card.name,
+                card.selectedOption?.setCode,
+                card.selectedOption?.collectorNumber,
+            ].join("|");
+        },
+        buildPairedGamePieceSlots(cards) {
+            const normalCards = [];
+            const gamePieces = [];
+
+            for (const card of cards) {
+                if (this.isGamePieceCard(card)) {
+                    gamePieces.push(card);
+                } else {
+                    normalCards.push(card);
+                }
+            }
+
+            const pairs = normalCards.map(card => {
+                return {
+                    front: { card, face: "front" },
+                    back: { card, face: "back" },
+                };
+            });
+
+            const groups = new Map();
+            for (const card of gamePieces) {
+                const key = this.gamePieceKey(card);
+                groups.set(key, groups.get(key) ?? []);
+                groups.get(key).push(card);
+            }
+
+            while (groups.size > 0) {
+                const sortedGroups = Array.from(groups.entries()).sort((a, b) => {
+                    return b[1].length - a[1].length;
+                });
+                const [frontKey, frontGroup] = sortedGroups[0];
+                const front = frontGroup.shift();
+                if (frontGroup.length === 0) {
+                    groups.delete(frontKey);
+                }
+
+                const backEntry = Array.from(groups.entries())
+                    .sort((a, b) => b[1].length - a[1].length)
+                    .find(([backKey]) => backKey !== frontKey);
+                let back = null;
+
+                if (backEntry) {
+                    const [backKey, backGroup] = backEntry;
+                    back = backGroup.shift();
+                    if (backGroup.length === 0) {
+                        groups.delete(backKey);
+                    }
+                }
+
+                pairs.push({
+                    front: { card: front, face: "front" },
+                    back: back ? { card: back, face: "front" } : null,
+                });
+            }
+
+            return {
+                frontSlots: pairs.map(pair => pair.front),
+                backSlots: pairs.map(pair => pair.back),
+            };
+        },
         async loadSetList() {
           const dataset = (await ScryfallDatasetAsync());
           this.sets = dataset.sets;
@@ -569,7 +686,7 @@ export default {
               if (
                 this.config.cardBacks === "all-pages" &&
                 this.config.tokenBackMode === "opposite" &&
-                card.selectedOption.isToken
+                card.selectedOption.isGamePiece
               ) {
                 return setImageVersion(
                   card.selectedOption.urlFront,
@@ -579,7 +696,7 @@ export default {
 
               if (
                 this.config.cardBacks === "token-pairs" &&
-                card.selectedOption.isToken &&
+                card.selectedOption.isGamePiece &&
                 card.tokenBackUrl
               ) {
                 return setImageVersion(
@@ -655,10 +772,15 @@ export default {
                             isDigital: option.isDigital,
                             isPromo: option.isPromo,
                             isToken: option.isToken,
+                            isGamePiece: option.isGamePiece,
+                            relatedTokens: option.relatedTokens,
                         };
                     }),
                     isBasic: basicLands.includes(line.name.toLowerCase()),
+                    requestedSet: line.set,
+                    requestedCollectorNumber: line.collectorsNumber,
                     selectedOption: this.sessionSetSelections[line.name]?.[cardIndex],
+                    selectedFromSession: Boolean(this.sessionSetSelections[line.name]?.[cardIndex]),
                 };
 
                 if (!options.selectedOption) {
@@ -670,10 +792,18 @@ export default {
                         })?.[0] ?? undefined;
                     }
 
+                    if (!options.selectedOption && line.set) {
+                        options.selectedOption = options.setOptions.find(option => {
+                            return option.isGamePiece &&
+                                option.setCode === line.set &&
+                                (!line.collectorsNumber || option.collectorNumber == line.collectorsNumber);
+                        });
+                    }
+
                     // If we failed there, then we can set a default based on characteristics.
                     if (!options.selectedOption) {
                         options.selectedOption = options.setOptions.filter(option => {
-                            return !option.isDigital && !option.isPromo && !option.isToken;
+                            return !option.isDigital && !option.isPromo && !option.isGamePiece;
                         })?.[0] ?? options.setOptions[0];
                     }
                 }
@@ -681,15 +811,50 @@ export default {
                 _cards.push(options);
             }
 
+            this.applySessionRelatedTokenSelections(_cards);
+
             this.cards = _cards;
 
             // attach tokenBackUrl when token-pairs mode is enabled
             if (this.config.cardBacks === 'token-pairs') {
               for (const c of this.cards) {
-                if (c.selectedOption && c.selectedOption.isToken) {
+                if (c.selectedOption && c.selectedOption.isGamePiece) {
                   c.tokenBackUrl = this.getTokenPairBackUrl(c.selectedOption.urlFront, c.name);
                 }
               }
+            }
+        },
+        applySessionRelatedTokenSelections(cards) {
+            const relatedTokens = cards
+                .filter(card => !card.selectedOption?.isGamePiece)
+                .flatMap(card => card.selectedOption?.relatedTokens ?? []);
+
+            for (const card of cards) {
+                if (!card.selectedOption?.isGamePiece || card.selectedFromSession) {
+                    continue;
+                }
+
+                if (card.requestedSet && card.requestedCollectorNumber) {
+                    continue;
+                }
+
+                const relatedToken = relatedTokens.find(token => {
+                    return token.name === card.name &&
+                        (!card.requestedSet || token.setCode === card.requestedSet) &&
+                        (!card.requestedCollectorNumber || token.collectorNumber == card.requestedCollectorNumber);
+                });
+
+                if (!relatedToken) {
+                    continue;
+                }
+
+                const selectedOption = card.setOptions.find(option => {
+                    return option.isGamePiece &&
+                        option.setCode === (card.requestedSet ?? relatedToken.setCode) &&
+                        option.collectorNumber == (card.requestedCollectorNumber ?? relatedToken.collectorNumber);
+                });
+
+                card.selectedOption = selectedOption ?? card.selectedOption;
             }
         },
     },

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -117,6 +117,13 @@
                 <i class="form-icon" /> Fixed page size (3×3)
               </label>
             </div>
+            <div class="column col-12">
+              <label class="form-label">
+                <i class="form-icon" /> Cards per page
+                <input type="number" min="1" max="36" class="form-input" v-model.number="config.cardsPerPage" style="width:100%" />
+                <small class="form-help">Used when <strong>Card backs</strong> = All pages and Fixed page size is unchecked.</small>
+              </label>
+            </div>
           </div>
           <div class="column col-12 divider" />
           <div class="columns">
@@ -359,7 +366,7 @@ export default {
                 imageType: "border_crop",
                 scale: "normal",
                 cardBacks: "dfc",
-                   cardsPerPage: null,
+                   cardsPerPage: 9,
                 decklist: "",
             },
             sets: {},

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -417,17 +417,27 @@ export default {
             }
 
             if (this.config.cardBacks === "all-pages") {
-                const frontSlots = this.printSlotsFront.map((card) => {
-                    return { card, face: "front" };
-                });
-                const backSlots = this.printSlotsFront.map((card) => {
-                    return { card, face: "back" };
-                });
+              const frontSlots = this.printSlotsFront.map((card) => {
+                return { card, face: "front" };
+              });
+              const backSlots = this.printSlotsFront.map((card) => {
+                return { card, face: "back" };
+              });
 
-                return [
-                    ...toPages(frontSlots, false),
-                    ...toPages(backSlots, true),
-                ];
+              const frontPages = toPages(frontSlots, false);
+              const backPages = toPages(backSlots, true);
+              const pages = [];
+
+              for (let i = 0; i < Math.max(frontPages.length, backPages.length); i += 1) {
+                if (frontPages[i]) {
+                  pages.push(frontPages[i]);
+                }
+                if (backPages[i]) {
+                  pages.push(backPages[i]);
+                }
+              }
+
+              return pages;
             }
 
             const slots = [];

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -172,9 +172,15 @@
                   <option value="none">{{ $t('configuration.cardBacks.none') }}</option>
                   <option value="dfc">{{ $t('configuration.cardBacks.dfcs') }}</option>
                   <option value="all">{{ $t('configuration.cardBacks.all') }}</option>
-                  <option value="all-pages">{{ $t('configuration.cardBacks.allPages') }}</option>
+                    <option value="all-pages">{{ $t('configuration.cardBacks.allPages') }}</option>
                 </select>
               </label>
+                <div v-if="config.cardBacks === 'all-pages' && !config.fixedPageSize" style="margin-top:0.5rem">
+                  <label class="form-label">
+                    <i class="form-icon" /> Cards per page (leave empty to group all fronts/backs):
+                    <input type="number" min="1" max="36" class="form-input" v-model.number="config.cardsPerPage" style="width:100%" />
+                  </label>
+                </div>
             </div>
           </div>
           <div class="column col-12 divider" />
@@ -353,6 +359,7 @@ export default {
                 imageType: "border_crop",
                 scale: "normal",
                 cardBacks: "dfc",
+                   cardsPerPage: null,
                 decklist: "",
             },
             sets: {},
@@ -393,19 +400,34 @@ export default {
             return slots;
         },
         printPages() {
-            const toPages = (slots, isBack) => {
-                if (this.config.fixedPageSize) {
-                    const pages = [];
-                    for (let i = 0; i < slots.length; i += 9) {
-                        const page = slots.slice(i, i + 9);
-                        while (page.length < 9) {
-                            page.push(null);
-                        }
-                        pages.push({ slots: page, isBack });
-                    }
-                    return pages.length ? pages : [];
+            const toPages = (slots, isBack, pageSize = null) => {
+              // If a pageSize is provided (number), paginate into that size.
+              if (pageSize && Number.isInteger(pageSize) && pageSize > 0) {
+                const pages = [];
+                for (let i = 0; i < slots.length; i += pageSize) {
+                  const page = slots.slice(i, i + pageSize);
+                  while (page.length < pageSize) {
+                    page.push(null);
+                  }
+                  pages.push({ slots: page, isBack });
                 }
-                return [{ slots, isBack }];
+                return pages.length ? pages : [];
+              }
+
+              // Fallback to old behavior: if fixedPageSize true, use 9 slots; otherwise return a single page.
+              if (this.config.fixedPageSize) {
+                const pages = [];
+                for (let i = 0; i < slots.length; i += 9) {
+                  const page = slots.slice(i, i + 9);
+                  while (page.length < 9) {
+                    page.push(null);
+                  }
+                  pages.push({ slots: page, isBack });
+                }
+                return pages.length ? pages : [];
+              }
+
+              return [{ slots, isBack }];
             };
 
             if (this.config.cardBacks === "none") {
@@ -424,8 +446,9 @@ export default {
                 return { card, face: "back" };
               });
 
-              const frontPages = toPages(frontSlots, false);
-              const backPages = toPages(backSlots, true);
+              const pageSize = this.config.fixedPageSize ? 9 : (this.config.cardsPerPage ?? null);
+              const frontPages = toPages(frontSlots, false, pageSize);
+              const backPages = toPages(backSlots, true, pageSize);
               const pages = [];
 
               for (let i = 0; i < Math.max(frontPages.length, backPages.length); i += 1) {

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -120,7 +120,7 @@
             <div class="column col-12">
               <label class="form-label">
                 <i class="form-icon" /> Cards per page
-                <input type="number" min="1" max="36" class="form-input" v-model.number="config.cardsPerPage" style="width:100%" />
+                <input type="number" min="1" max="36" class="form-input" v-model.number="config.cardsPerPage" placeholder="9" style="width:100%" />
                 <small class="form-help">Used when <strong>Card backs</strong> = All pages and Fixed page size is unchecked.</small>
               </label>
             </div>
@@ -366,7 +366,7 @@ export default {
                 imageType: "border_crop",
                 scale: "normal",
                 cardBacks: "dfc",
-                   cardsPerPage: 9,
+                   cardsPerPage: null,
                 decklist: "",
             },
             sets: {},

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -543,14 +543,15 @@ export default {
                     this.config.imageType,
                 );
             } else {
-                if (card.selectedOption.urlBack !== undefined) {
-                    return setImageVersion(
-                        card.selectedOption.urlBack,
-                        this.config.imageType,
-                    );
-                } else {
-                    return `./card_back_${this.config.imageType}.jpg`;
-                }
+              if (card.selectedOption.urlBack !== undefined) {
+                return setImageVersion(
+                  card.selectedOption.urlBack,
+                  this.config.imageType,
+                );
+              } else {
+                console.warn(`No urlBack for ${card.name}, using default back image`);
+                return `/card_back_${this.config.imageType}.jpg`;
+              }
             }
         },
         updateSessionSet(cardName, setOption, cardIndex) {

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -173,6 +173,7 @@
                   <option value="dfc">{{ $t('configuration.cardBacks.dfcs') }}</option>
                   <option value="all">{{ $t('configuration.cardBacks.all') }}</option>
                   <option value="all-pages">{{ $t('configuration.cardBacks.allPages') }}</option>
+                  <option value="token-pairs">{{ $t('configuration.cardBacks.tokenPairs') }}</option>
                 </select>
               </label>
             </div>
@@ -356,6 +357,8 @@ export default {
                 decklist: "",
             },
             sets: {},
+            tokenPool: [],
+            nextTokenBackIndex: 0,
             cards: [],
             errors: [],
             sessionSetSelections: {},
@@ -455,9 +458,18 @@ export default {
     },
     methods: {
         async loadSetList() {
-            const dataset = (await ScryfallDatasetAsync());
-            this.sets = dataset.sets;
-            console.log(`Loaded ${Object.keys(dataset.cards).length} distinct cards from ${Object.keys(dataset.sets).length} sets.`)
+          const dataset = (await ScryfallDatasetAsync());
+          this.sets = dataset.sets;
+          console.log(`Loaded ${Object.keys(dataset.cards).length} distinct cards from ${Object.keys(dataset.sets).length} sets.`)
+          // Build token pool for token-pairs mode
+          this.tokenPool = Object.values(dataset.cards)
+            .flat()
+            .filter((c) => c.cardFaces && c.cardFaces.length === 1 && c.cardFaces[0].type_line && /token/i.test(c.cardFaces[0].type_line))
+            .map((c) => ({
+              name: c.name,
+              urlBack: c.image_uris && c.image_uris.normal ? c.image_uris.normal : undefined,
+            }))
+            .filter((t) => t.urlBack);
         },
         initConfig() {
             this.config.includeDigital = bindStorage('includeDigital', (v) => v === "true");
@@ -488,9 +500,9 @@ export default {
             }
 
             if (face === "back") {
-                if (this.config.cardBacks === "all" || this.config.cardBacks === "all-pages") {
-                    return true;
-                }
+              if (this.config.cardBacks === "all" || this.config.cardBacks === "all-pages" || this.config.cardBacks === "token-pairs") {
+                return true;
+              }
 
                 if (
                     this.config.cardBacks === "none" ||
@@ -509,16 +521,38 @@ export default {
                     this.config.imageType,
                 );
             } else {
-                if (card.selectedOption.urlBack !== undefined) {
-                    return setImageVersion(
-                        card.selectedOption.urlBack,
-                        this.config.imageType,
-                    );
-                } else {
-                    return `./card_back_${this.config.imageType}.jpg`;
-                }
+              if (
+                this.config.cardBacks === "token-pairs" &&
+                card.selectedOption.isToken &&
+                card.tokenBackUrl
+              ) {
+                return setImageVersion(
+                  card.tokenBackUrl,
+                  this.config.imageType,
+                );
+              }
+
+              if (card.selectedOption.urlBack !== undefined) {
+                return setImageVersion(
+                  card.selectedOption.urlBack,
+                  this.config.imageType,
+                );
+              } else {
+                return `./card_back_${this.config.imageType}.jpg`;
+              }
             }
         },
+
+          getTokenPairBackUrl(frontUrl, cardName) {
+            if (!this.tokenPool || !this.tokenPool.length) return undefined;
+
+            const pool = this.tokenPool.filter((t) => t.urlBack !== frontUrl && t.name !== cardName);
+            if (!pool.length) return undefined;
+
+            const idx = this.nextTokenBackIndex % pool.length;
+            this.nextTokenBackIndex += 1;
+            return pool[idx].urlBack;
+          },
         updateSessionSet(cardName, setOption, cardIndex) {
             const deckIndex = this.cards.filter((v, i) => { return v.name === cardName && i <= cardIndex; }).length - 1;
             this.sessionSetSelections[cardName] = this.sessionSetSelections[cardName] ?? {};
@@ -533,6 +567,7 @@ export default {
 
             const { lines, errors } = parseDecklist(this.config.decklist);
             this.errors = errors;
+            
 
             const _cards = [];
 
@@ -590,6 +625,15 @@ export default {
             }
 
             this.cards = _cards;
+
+            // attach tokenBackUrl when token-pairs mode is enabled
+            if (this.config.cardBacks === 'token-pairs') {
+              for (const c of this.cards) {
+                if (c.selectedOption && c.selectedOption.isToken) {
+                  c.tokenBackUrl = this.getTokenPairBackUrl(c.selectedOption.urlFront, c.name);
+                }
+              }
+            }
         },
     },
 };

--- a/src/views/ProxyPage.vue
+++ b/src/views/ProxyPage.vue
@@ -176,6 +176,15 @@
                   <option value="token-pairs">{{ $t('configuration.cardBacks.tokenPairs') }}</option>
                 </select>
               </label>
+              <div v-if="config.cardBacks === 'all-pages'" style="margin-top: 0.5rem">
+                <label class="form-label">
+                  <i class="form-icon" /> Token backs: 
+                  <select class="form-select select" v-model="config.tokenBackMode" style="width: 100%">
+                    <option value="card">Use regular card back</option>
+                    <option value="opposite">Use token face on opposite side</option>
+                  </select>
+                </label>
+              </div>
             </div>
           </div>
           <div class="column col-12 divider" />
@@ -354,6 +363,7 @@ export default {
                 imageType: "border_crop",
                 scale: "normal",
                 cardBacks: "dfc",
+                tokenBackMode: "card",
                 decklist: "",
             },
             sets: {},
@@ -521,6 +531,18 @@ export default {
                     this.config.imageType,
                 );
             } else {
+              // If all-pages + token opposite mode, use the token's front as the back image
+              if (
+                this.config.cardBacks === "all-pages" &&
+                this.config.tokenBackMode === "opposite" &&
+                card.selectedOption.isToken
+              ) {
+                return setImageVersion(
+                  card.selectedOption.urlFront,
+                  this.config.imageType,
+                );
+              }
+
               if (
                 this.config.cardBacks === "token-pairs" &&
                 card.selectedOption.isToken &&


### PR DESCRIPTION
## Summary
- Parse Moxfield wishlist/token lines with bracketed set codes, collector numbers, and trailing tags.
- Enrich minimized Scryfall data with flavor-name aliases, game-piece classification, and related token metadata.
- Resolve incomplete token/game-piece imports from associated cards in the same session.
- Pack game pieces onto opposite sides without duplicating identical pieces, and show remaining physical slots/game-piece faces.

## Validation
- `npm run cards`
- `npm test` (64 passed)
- `npm run lint` (passes with existing Vue style warnings)

UI note: code-level/test validation only; no screenshot verification was captured.